### PR TITLE
Fix #1:  Replace Cu.waiveXrays with internal API calls for the IDB storage back end

### DIFF
--- a/bug_1292234.diff
+++ b/bug_1292234.diff
@@ -1,15 +1,24 @@
+# HG changeset patch
+# User Bianca Danforth <bdanforth@mozilla.com>
+# Date 1553039428 25200
+#      Tue Mar 19 16:50:28 2019 -0700
+# Node ID fc3c4f4be722a1471921f36d1a861fbc9ab57ad6
+# Parent  25398e555020fef80c7b2a06a0d4c667e861cd6f
+Bug 1292234 - Prototype extension storage in addon developer toolbox
+
 diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.js
 --- a/devtools/server/actors/storage.js
 +++ b/devtools/server/actors/storage.js
-@@ -12,6 +12,7 @@ const Services = require("Services");
+@@ -12,6 +12,8 @@ const Services = require("Services");
  const defer = require("devtools/shared/defer");
  const {isWindowIncluded} = require("devtools/shared/layout/utils");
  const specs = require("devtools/shared/specs/storage");
 +const {ExtensionProcessScript} = require("resource://gre/modules/ExtensionProcessScript.jsm");
++const {ExtensionStorageIDB} = require("resource://gre/modules/ExtensionStorageIDB.jsm");
  
  const CHROME_ENABLED_PREF = "devtools.chrome.enabled";
  const REMOTE_ENABLED_PREF = "devtools.debugger.remote-enabled";
-@@ -1298,6 +1299,233 @@ StorageActors.createActor({
+@@ -1298,6 +1300,250 @@ StorageActors.createActor({
    observationTopics: ["dom-storage2-changed", "dom-private-storage2-changed"],
  }, getObjectForLocalOrSessionStorage("sessionStorage"));
  
@@ -128,6 +137,16 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    }
 +  },
 +
++  async populateStoreMap(storagePrincipal, storeMap) {
++    const db = await ExtensionStorageIDB.open(storagePrincipal);
++    const data = await db.get();
++
++    for (const [key, value] of Object.entries(data)) {
++      storeMap.set(key, value);
++    }
++    return storeMap;
++  },
++
 +  /**
 +  * This method asynchronously reads the browser.storage.local data for the window
 +  * (if it's an extension page window and the related extension has the storage
@@ -137,7 +156,6 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    if (this.hostVsStores.has(host)) {
 +      return;
 +    }
-+
 +    const storeMap = new Map();
 +    const principal = this.getPrincipal(window);
 +    const { addonId } = principal;
@@ -145,14 +163,22 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    const extension = ExtensionProcessScript.getExtensionChild(addonId);
 +
 +    if (extension && extension.hasPermission("storage")) {
-+      // TODO: Using the browser.storage.local API after unwaive the x-rays of the
-+      // extension page window is a temporary hacky shortcut to be able to quickly
-+      // put together the prototype, as the browser object could be overridden by
-+      // the extension code.
-+      const data = await Cu.waiveXrays(window).browser.storage.local.get();
++      // TODO: Cover the case when the extension was just installed, has not yet
++      // migrated to the storage IDB backend (this is done lazily) here:
++      // https://searchfox.org/mozilla-central/source/toolkit/components/extensions/Extension.jsm#1940-1948
++      // Therefore `extension.getSharedData("storageIDBBackend")` is `null`.
++      // Temporary workaround is simply to reload the extension before opening the
++      // storage inspector.
++      if (extension.getSharedData("storageIDBBackend")) {
++        // This extension is using the storageIDBBackend
++        const storagePrincipal = extension.getSharedData("storageIDBPrincipal");
 +
-+      for (const [key, value] of Object.entries(data)) {
-+        storeMap.set(key, value);
++        const db = await ExtensionStorageIDB.open(storagePrincipal);
++        const data = await db.get();
++
++        for (const [key, value] of Object.entries(data)) {
++          storeMap.set(key, value);
++        }
 +      }
 +    }
 +

--- a/bug_1292234.diff
+++ b/bug_1292234.diff
@@ -2,14 +2,14 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1553039428 25200
 #      Tue Mar 19 16:50:28 2019 -0700
-# Node ID 9f0d9d7718e1036d6f4844af99d790f3b1c0810a
+# Node ID c19c8d95c45194be5c47d79ad5e2d830f411a49c
 # Parent  25398e555020fef80c7b2a06a0d4c667e861cd6f
 Bug 1292234 - Prototype extension storage in addon developer toolbox
 
 diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.js
 --- a/devtools/server/actors/storage.js
 +++ b/devtools/server/actors/storage.js
-@@ -12,6 +12,8 @@ const Services = require("Services");
+@@ -12,12 +12,16 @@ const Services = require("Services");
  const defer = require("devtools/shared/defer");
  const {isWindowIncluded} = require("devtools/shared/layout/utils");
  const specs = require("devtools/shared/specs/storage");
@@ -18,7 +18,15 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
  
  const CHROME_ENABLED_PREF = "devtools.chrome.enabled";
  const REMOTE_ENABLED_PREF = "devtools.debugger.remote-enabled";
-@@ -1298,6 +1300,263 @@ StorageActors.createActor({
+ 
+ const DEFAULT_VALUE = "value";
+ 
++const DEVTOOLS_EXT_STORAGELOCAL_CHANGED = "Extension:DevTools:OnStorageLocalChanged";
++
+ loader.lazyRequireGetter(this, "naturalSortCaseInsensitive",
+   "devtools/client/shared/natural-sort", true);
+ 
+@@ -1298,6 +1302,273 @@ StorageActors.createActor({
    observationTopics: ["dom-storage2-changed", "dom-private-storage2-changed"],
  }, getObjectForLocalOrSessionStorage("sessionStorage"));
  
@@ -33,9 +41,15 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +
 +    this.storageActor = storageActor;
 +
-+    this.populateStoresForHosts();
++    // Map<host, ExtensionStorageIDB db connection>
++    this.dbConnectionForHost = new Map();
 +
-+    this.addExtensionStorageListeners();
++    this.onStorageChange = this.onStorageChange.bind(this);
++
++    this.conn.parentMessageManager.addMessageListener(
++      DEVTOOLS_EXT_STORAGELOCAL_CHANGED, this.onStorageChange);
++
++    this.populateStoresForHosts();
 +
 +    this.onWindowReady = this.onWindowReady.bind(this);
 +    this.onWindowDestroyed = this.onWindowDestroyed.bind(this);
@@ -44,7 +58,8 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +  },
 +
 +  destroy() {
-+    this.removeExtensionStorageListeners();
++    this.conn.parentMessageManager.removeMessageListener(
++      DEVTOOLS_EXT_STORAGELOCAL_CHANGED, this.onStorageChange);
 +
 +    this.storageActor.off("window-ready", this.onWindowReady);
 +    this.storageActor.off("window-destroyed", this.onWindowDestroyed);
@@ -57,11 +72,15 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +  },
 +
 +  /**
-+  * Ensures this.hostVsStores stays up-to-date and passes the change on
-+  * to update the view.
++  * This fires when the extension changes storage data while the storage
++  * inspector is open. Ensures this.hostVsStores stays up-to-date and
++  * passes the change on to update the view.
 +  */
-+  onStorageChange(changes, areaName) {
-+    if (areaName !== "local") {
++  onStorageChange({name, data}) {
++    const host = `moz-extension://${data.extensionUUID}`;
++    const changes = data.changes;
++    const storeMap = this.hostVsStores.get(host);
++    if (!storeMap) {
 +      return;
 +    }
 +
@@ -69,18 +88,7 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +      const storageChange = changes[key];
 +      const {newValue, oldValue} = storageChange;
 +
-+      // TODO: Not sure what the best way is to get the current host.
-+      let host = null;
-+      for (const window of this.windows) {
-+        host = this.getHostName(window.location);
-+        if (host) {
-+          break;
-+        }
-+      }
-+
-+      let action = null;
-+      const storeMap = this.hostVsStores.get(host);
-+
++      let action;
 +      if (typeof newValue === "undefined") {
 +        action = "deleted";
 +        storeMap.delete(key);
@@ -93,23 +101,6 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +      }
 +
 +      this.storageActor.update(action, this.typeName, {[host]: [key]});
-+    }
-+  },
-+
-+  // TODO: Don't use WE APIs directly
-+  addExtensionStorageListeners() {
-+    this.onStorageChange = this.onStorageChange.bind(this);
-+    for (const window of this.windows) {
-+      Cu.waiveXrays(window).browser.storage.onChanged.addListener(this.onStorageChange);
-+    }
-+  },
-+
-+  // TODO: Don't use WE APIs directly
-+  removeExtensionStorageListeners() {
-+    for (const window of this.windows) {
-+      Cu.waiveXrays(window).browser.storage.onChanged.removeListener(
-+        this.onStorageChange
-+      );
 +    }
 +  },
 +
@@ -137,8 +128,9 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    }
 +  },
 +
-+  async populateStoreMap(storagePrincipal, storeMap) {
++  async populateStoreMap(host, storagePrincipal, storeMap) {
 +    const db = await ExtensionStorageIDB.open(storagePrincipal);
++    this.dbConnectionForHost.set(host, db);
 +    const data = await db.get();
 +
 +    for (const [key, value] of Object.entries(data)) {
@@ -185,13 +177,13 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +          } = await ExtensionStorageIDB.selectBackend(context);
 +
 +          if (backendEnabled) {
-+            storeMap = await this.populateStoreMap(storagePrincipal, storeMap);
++            storeMap = await this.populateStoreMap(host, storagePrincipal, storeMap);
 +          }
 +        }
 +      } else if (isUsingIDBBackend) {
 +        const storagePrincipal = extension.getSharedData("storageIDBPrincipal");
 +
-+        storeMap = await this.populateStoreMap(storagePrincipal, storeMap);
++        storeMap = await this.populateStoreMap(host, storagePrincipal, storeMap);
 +      }
 +    }
 +
@@ -249,33 +241,59 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    ];
 +  },
 +
-+  // TODO: Don't use WE APIs directly
 +  async addItem(guid, host) {
-+    const win = this.storageActor.getWindowFromHost(host);
-+    await Cu.waiveXrays(win).browser.storage.local.set({[guid]: DEFAULT_VALUE});
++    const db = this.dbConnectionForHost.get(host);
++    if (!db) {
++      return;
++    }
++    const changes = await db.set({[guid]: DEFAULT_VALUE});
++    this.fireOnChangedExtensionEvent(host, changes);
 +  },
 +
-+  // TODO: Don't use WE APIs directly
 +  async editItem({host, field, items, oldValue}) {
-+    const win = this.storageActor.getWindowFromHost(host);
++    const db = this.dbConnectionForHost.get(host);
++    if (!db) {
++      return;
++    }
++
 +    const {name, value} = items;
 +    // If the name changed, remove the previous entry in storage by the old name first
 +    if (field === "name") {
-+      await Cu.waiveXrays(win).browser.storage.local.remove(oldValue);
++      const changes = await db.remove(oldValue);
++      this.fireOnChangedExtensionEvent(host, changes);
 +    }
-+    await Cu.waiveXrays(win).browser.storage.local.set({[name]: value});
++    const changes = await db.set({[name]: value});
++    this.fireOnChangedExtensionEvent(host, changes);
 +  },
 +
-+  // TODO: Don't use WE APIs directly
 +  async removeItem(host, name) {
-+    const win = this.storageActor.getWindowFromHost(host);
-+    await Cu.waiveXrays(win).browser.storage.local.remove(name);
++    const db = this.dbConnectionForHost.get(host);
++    if (!db) {
++      return;
++    }
++
++    const changes = await db.remove(name);
++    this.fireOnChangedExtensionEvent(host, changes);
 +  },
 +
-+  // TODO: Don't use WE APIs directly
 +  async removeAll(host) {
-+    const win = this.storageActor.getWindowFromHost(host);
-+    await Cu.waiveXrays(win).browser.storage.local.clear();
++    const db = this.dbConnectionForHost.get(host);
++    if (!db) {
++      return;
++    }
++
++    const changes = await db.clear();
++    this.fireOnChangedExtensionEvent(host, changes);
++  },
++
++  /**
++  * Let the extension know that storage data has been changed by the user from
++  * the storage inspector.
++  */
++  fireOnChangedExtensionEvent(host, changes) {
++    const uuid = (new URL(host)).host;
++    Services.cpmm.sendAsyncMessage(`Extension:StorageLocalOnChanged:${uuid}`,
++                                   changes);
 +  },
 +});
 +
@@ -326,3 +344,53 @@ diff --git a/devtools/shared/specs/storage.js b/devtools/shared/specs/storage.js
  types.addDictType("cacheobject", {
    "url": "string",
    "status": "string",
+diff --git a/toolkit/components/extensions/parent/ext-storage.js b/toolkit/components/extensions/parent/ext-storage.js
+--- a/toolkit/components/extensions/parent/ext-storage.js
++++ b/toolkit/components/extensions/parent/ext-storage.js
+@@ -1,5 +1,7 @@
+ "use strict";
+ 
++/* global ExtensionParent */
++
+ XPCOMUtils.defineLazyModuleGetters(this, {
+   AddonManagerPrivate: "resource://gre/modules/AddonManager.jsm",
+   ExtensionStorage: "resource://gre/modules/ExtensionStorage.jsm",
+@@ -37,6 +39,21 @@ const lookupManagedStorage = async (exte
+   return null;
+ };
+ 
++// Notify storage actor when storage data has changed if the extension is targeted
++// by a developer toolbox.
++function notifyDevToolsListeners(extension, changes) {
++  const {DebugUtils} = ExtensionParent;
++  let debugBrowserPromise = DebugUtils.debugBrowserPromises.get(extension.id);
++  if (debugBrowserPromise) {
++    (async () => {
++      const browser = await debugBrowserPromise;
++      browser.messageManager.sendAsyncMessage(
++        `Extension:DevTools:OnStorageLocalChanged`,
++        {changes, extensionUUID: extension.uuid});
++    })();
++  }
++}
++
+ this.storage = class extends ExtensionAPI {
+   constructor(extension) {
+     super(extension);
+@@ -63,6 +80,8 @@ this.storage = class extends ExtensionAP
+     }
+ 
+     ExtensionStorageIDB.notifyListeners(this.extension.id, data);
++
++    notifyDevToolsListeners(this.extension, data);
+   }
+ 
+   getAPI(context) {
+@@ -82,6 +101,7 @@ this.storage = class extends ExtensionAP
+             const changes = await db[method](...args);
+             if (changes) {
+               ExtensionStorageIDB.notifyListeners(extension.id, changes);
++              notifyDevToolsListeners(extension, changes);
+             }
+             return changes;
+           },

--- a/bug_1292234.diff
+++ b/bug_1292234.diff
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1553039428 25200
 #      Tue Mar 19 16:50:28 2019 -0700
-# Node ID fc3c4f4be722a1471921f36d1a861fbc9ab57ad6
+# Node ID 9f0d9d7718e1036d6f4844af99d790f3b1c0810a
 # Parent  25398e555020fef80c7b2a06a0d4c667e861cd6f
 Bug 1292234 - Prototype extension storage in addon developer toolbox
 
@@ -18,7 +18,7 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
  
  const CHROME_ENABLED_PREF = "devtools.chrome.enabled";
  const REMOTE_ENABLED_PREF = "devtools.debugger.remote-enabled";
-@@ -1298,6 +1300,250 @@ StorageActors.createActor({
+@@ -1298,6 +1300,263 @@ StorageActors.createActor({
    observationTopics: ["dom-storage2-changed", "dom-private-storage2-changed"],
  }, getObjectForLocalOrSessionStorage("sessionStorage"));
  
@@ -156,29 +156,42 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    if (this.hostVsStores.has(host)) {
 +      return;
 +    }
-+    const storeMap = new Map();
++
++    let storeMap = new Map();
 +    const principal = this.getPrincipal(window);
 +    const { addonId } = principal;
 +    // TODO: Get extension object from the parent instead?
 +    const extension = ExtensionProcessScript.getExtensionChild(addonId);
 +
 +    if (extension && extension.hasPermission("storage")) {
-+      // TODO: Cover the case when the extension was just installed, has not yet
-+      // migrated to the storage IDB backend (this is done lazily) here:
-+      // https://searchfox.org/mozilla-central/source/toolkit/components/extensions/Extension.jsm#1940-1948
-+      // Therefore `extension.getSharedData("storageIDBBackend")` is `null`.
-+      // Temporary workaround is simply to reload the extension before opening the
-+      // storage inspector.
-+      if (extension.getSharedData("storageIDBBackend")) {
-+        // This extension is using the storageIDBBackend
++      const isUsingIDBBackend = extension.getSharedData("storageIDBBackend");
++      if (isUsingIDBBackend === null) {
++        // Extension has not yet migrated to the IDB backend; trigger migration
++
++        // TODO: Create own context object rather than getting from the view?
++        let context;
++        const {views} = extension;
++        for (const view of views) {
++          context = view.childManager.context;
++          if (context) {
++            break;
++          }
++        }
++
++        if (context) {
++          const {
++            backendEnabled,
++            storagePrincipal,
++          } = await ExtensionStorageIDB.selectBackend(context);
++
++          if (backendEnabled) {
++            storeMap = await this.populateStoreMap(storagePrincipal, storeMap);
++          }
++        }
++      } else if (isUsingIDBBackend) {
 +        const storagePrincipal = extension.getSharedData("storageIDBPrincipal");
 +
-+        const db = await ExtensionStorageIDB.open(storagePrincipal);
-+        const data = await db.get();
-+
-+        for (const [key, value] of Object.entries(data)) {
-+          storeMap.set(key, value);
-+        }
++        storeMap = await this.populateStoreMap(storagePrincipal, storeMap);
 +      }
 +    }
 +

--- a/bug_1292234.patch
+++ b/bug_1292234.patch
@@ -2,7 +2,7 @@
 # User Bianca Danforth <bdanforth@mozilla.com>
 # Date 1553039428 25200
 #      Tue Mar 19 16:50:28 2019 -0700
-# Node ID c19c8d95c45194be5c47d79ad5e2d830f411a49c
+# Node ID edfd1d90740f3d699cb022b76de2200f8f822d6b
 # Parent  25398e555020fef80c7b2a06a0d4c667e861cd6f
 Bug 1292234 - Prototype extension storage in addon developer toolbox
 
@@ -26,7 +26,7 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
  loader.lazyRequireGetter(this, "naturalSortCaseInsensitive",
    "devtools/client/shared/natural-sort", true);
  
-@@ -1298,6 +1302,273 @@ StorageActors.createActor({
+@@ -1298,6 +1302,279 @@ StorageActors.createActor({
    observationTopics: ["dom-storage2-changed", "dom-private-storage2-changed"],
  }, getObjectForLocalOrSessionStorage("sessionStorage"));
  
@@ -128,15 +128,32 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +    }
 +  },
 +
-+  async populateStoreMap(host, storagePrincipal, storeMap) {
-+    const db = await ExtensionStorageIDB.open(storagePrincipal);
-+    this.dbConnectionForHost.set(host, db);
-+    const data = await db.get();
-+
-+    for (const [key, value] of Object.entries(data)) {
-+      storeMap.set(key, value);
++  async getStoragePrincipal(extension) {
++    if (extension.getSharedData("storageIDBBackend")) {
++      return extension.getSharedData("storageIDBPrincipal");
 +    }
-+    return storeMap;
++    // This extension either isn't using the IDB backend (false) or
++    // it hasn't migrated to the IDB backend yet (null)
++
++    // Loop for web extension context related to the current window
++    let currentContext;
++    for (const view of extension.views) {
++      currentContext = view;
++    }
++    if (!currentContext) {
++      // We didn't find the extension context for the current target; give up.
++      return null;
++    }
++    const {
++      backendEnabled,
++      storagePrincipal,
++    } = await ExtensionStorageIDB.selectBackend(currentContext);
++
++    if (!backendEnabled) {
++      // IDB backend disabled; give up.
++      return null;
++    }
++    return storagePrincipal;
 +  },
 +
 +  /**
@@ -144,58 +161,47 @@ diff --git a/devtools/server/actors/storage.js b/devtools/server/actors/storage.
 +  * (if it's an extension page window and the related extension has the storage
 +  * permission) and caches this data into this.hostVsStores.
 +  */
-+  async populateStoresForHost(host, window) {
++  async populateStoresForHost(host, window = this.storageActor.window) {
 +    if (this.hostVsStores.has(host)) {
 +      return;
 +    }
 +
-+    let storeMap = new Map();
 +    const principal = this.getPrincipal(window);
-+    const { addonId } = principal;
-+    // TODO: Get extension object from the parent instead?
-+    const extension = ExtensionProcessScript.getExtensionChild(addonId);
++    const extension = ExtensionProcessScript.getExtensionChild(principal.addonId);
 +
-+    if (extension && extension.hasPermission("storage")) {
-+      const isUsingIDBBackend = extension.getSharedData("storageIDBBackend");
-+      if (isUsingIDBBackend === null) {
-+        // Extension has not yet migrated to the IDB backend; trigger migration
++    if (!extension || !(extension.hasPermission("storage"))) {
++      return;
++    }
 +
-+        // TODO: Create own context object rather than getting from the view?
-+        let context;
-+        const {views} = extension;
-+        for (const view of views) {
-+          context = view.childManager.context;
-+          if (context) {
-+            break;
-+          }
-+        }
++    const storagePrincipal = await this.getStoragePrincipal(extension);
 +
-+        if (context) {
-+          const {
-+            backendEnabled,
-+            storagePrincipal,
-+          } = await ExtensionStorageIDB.selectBackend(context);
++    if (!storagePrincipal) {
++      return;
++    }
 +
-+          if (backendEnabled) {
-+            storeMap = await this.populateStoreMap(host, storagePrincipal, storeMap);
-+          }
-+        }
-+      } else if (isUsingIDBBackend) {
-+        const storagePrincipal = extension.getSharedData("storageIDBPrincipal");
++    const db = await ExtensionStorageIDB.open(storagePrincipal);
++    this.dbConnectionForHost.set(host, db);
++    const data = await db.get();
 +
-+        storeMap = await this.populateStoreMap(host, storagePrincipal, storeMap);
-+      }
++    const storeMap = new Map();
++    for (const [key, value] of Object.entries(data)) {
++      storeMap.set(key, value);
 +    }
 +
 +    this.hostVsStores.set(host, storeMap);
 +  },
 +
 +  getValuesForHost(host, name) {
++    const result = [];
++
++    if (!this.hostVsStores.has(host)) {
++      return result;
++    }
++
 +    if (name) {
 +      return [{name, value: this.hostVsStores.get(host).get(name)}];
 +    }
 +
-+    const result = [];
 +    for (const [key, value] of Array.from(this.hostVsStores.get(host).entries())) {
 +      result.push({name: key, value});
 +    }


### PR DESCRIPTION
Since the extension storage data can be changed by the extension itself and by the developer modifying values in the Storage Inspector, we have to listen for both of these kinds of events and keep the extension storage data (in the IDB database) and cached UI storage data (`this.hostVsStores` in the storage actor) in sync.

**Cases handled:**
* [First and second commits] When the extension changes the storage data, and the storage inspector is _closed_
  - Handled by our storage actor’s `populateStoresForHost` method: when the storage inspector is next opened, we will retrieve the latest data stored in the IDB backend and populate the storage inspector UI.
* [Third commit] When the extension changes storage data, and the storage inspector is _open_
  - ./toolkit/components/extensions/parent/ext-storage.js (the parent process) sends a `"Extension:DevTools:OnStorageLocalChanged"` message via a XUL `browser` message manager to our storage actor (in the extension child process) with the change data.
* [Third commit] When the storage data is changed by the user from the Storage Inspector
  - We send a message from the storage actor (via its `fireOnChangedExtensionEvent` method) to the parent extension process when the storage data is changed through the storage inspector UI (say via `addItem`, `editItem`, etc.).